### PR TITLE
Add client_max_body_size to nginx.conf to fix HTTP 413 error

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -98,4 +98,7 @@ server {
 
     # Hide nginx version
     server_tokens off;
-} 
+
+    # Upload size limit
+    client_max_body_size 10M;
+}


### PR DESCRIPTION
I experienced an issue when using the frontend with a custom speech example. I got the following error in the browser console:
```
TTS generation failed:
Object { message: "Request failed with status code 413", name: "AxiosError", code: "ERR_BAD_REQUEST", config: {…}, request: XMLHttpRequest, response: {…}, status: 413, stack: "", … }
```
Adding `client_max_body_size 10M;` to the nginx.conf fixed it for me.