### PR TITLE
Create docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,34 @@
+name: 'Build'
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+    
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+     
+    steps:
+      - uses: actions/checkout@v4
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+     
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+  
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.USER }}/chatterbox-tts-api:${{ github.sha }}
+            ${{ env.USER }}/chatterbox-tts-api:latest
+          platforms: linux/amd64,linux/arm64/v8


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate building and publishing Docker images when changes are pushed to the `main` branch or the workflow is manually triggered. The workflow sets up Docker Buildx, logs in to Docker Hub using secrets, and builds and pushes multi-platform Docker images with both a commit-specific and a `latest` tag.

Just create the DOCKER_USERNAME and DOCKER_PASSWORD variables on the repository (from dockerhub)

**CI/CD automation:**

* Added `.github/workflows/docker-publish.yml` workflow to automatically build and push Docker images to Docker Hub on pushes to `main` or manual dispatch, including multi-platform support and tagging.