### PR TITLE
25-3.11UnavailableIn20.04

### DIFF
--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,5 +1,5 @@
 # Use NVIDIA CUDA runtime as base for better GPU support
-FROM nvidia/cuda:12.4.1-runtime-ubuntu20.04
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
Updated the base container of the GPU variant to 22.04 to resolve issue where python3.11 packages are unavailable in Ubuntu 20.04. This resolves #25.

Testing below.

- VSCode shows GPU variant running
- Task manager showing GPU utilization
- Frontend used to generate voice

[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/ldeQ0nCXMt4/0.jpg)](https://www.youtube.com/watch?v=ldeQ0nCXMt4)