### PR TITLE
Fix Python version requirement to support only 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "REST API for Chatterbox TTS with OpenAI compatibility"
 authors = [{ name = "Travis Van Nimwegen", email = "tts@travis2.com" }]
 readme = "README.md"
 license = { text = "AGPLv3" }
-requires-python = "~=3.11"
+requires-python = "~=3.11.0"
 dependencies = [
   # "chatterbox-tts @ git+https://github.com/resemble-ai/chatterbox.git",
   "chatterbox-tts @ git+https://github.com/travisvn/chatterbox-multilingual.git@exp",


### PR DESCRIPTION
The former version did not use patch version leading to the following warning when installing with `uv sync`:

```
warning: The `requires-python` specifier (`~=3.11`) in `chatterbox-tts-api`
uses the tilde specifier (`~=`) without a patch version. This will be
interpreted as `>=3.11, <4`. Did you mean `~=3.11.0` to constrain the version
as `>=3.11.0, <3.12`? We recommend only using the tilde specifier with a
patch version to avoid ambiguity.
```

As a result, Python 3.12 is incorrectly marked as supported, even though installation fails with the following errors:

```
Using CPython 3.12.6
Creating virtual environment at: .venv
Resolved 139 packages in 813ms
  × Failed to build `numpy==1.25.2`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 8, in <module>
        File "XXXXXXXX/builds-v0/.tmpZJ3M9v/lib/python3.12/site-packages/setuptools/__init__.py", line 10, in <module>
          import distutils.core
      ModuleNotFoundError: No module named 'distutils'

      hint: `distutils` was removed from the standard library in Python 3.12. Consider adding a constraint (like `numpy >1.25.2`) to avoid building a version of `numpy` that depends on `distutils`.
  help: `numpy` (v1.25.2) was included because `chatterbox-tts-api` (v2.0.0) depends on `chatterbox-tts` (v0.1.4) which depends on `numpy`
```

See also [Chatterbox installing issue #240](https://github.com/resemble-ai/chatterbox/issues/240)