### PR TITLE
Add setuptools as it's a missing dependency for Perth.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 chatterbox-tts @ git+https://github.com/travisvn/chatterbox-multilingual.git@exp
 
 # Required for Chatterbox TTS watermarker functionality
+setuptools
 resemble-perth
 
 # PyTorch with CPU support (ensure CPU compatibility)


### PR DESCRIPTION
Fixes "TypeError: 'NoneType' object is not callable" error. resemble-perth has a missing dependency (setuptools).

See: https://github.com/resemble-ai/Perth/issues/7